### PR TITLE
[feat] seo meta tag root layout

### DIFF
--- a/src/app/@modal/auth/layout.tsx
+++ b/src/app/@modal/auth/layout.tsx
@@ -4,8 +4,17 @@ import React from "react";
 import ModalBox from "@/components/atoms/ModalBox";
 import { HeaderBox } from "@/components/atoms/Box";
 import MenuTab from "@/components/molecules/MenuTab";
+import { usePathname } from "next/navigation";
 
-export default function layout({ children }: { children: React.ReactNode }) {
+export default function ModalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  if (pathname === "/") {
+    return;
+  }
   return (
     <ModalBox
       $width="320px"

--- a/src/app/@modal/letter/letterbox/layout.tsx
+++ b/src/app/@modal/letter/letterbox/layout.tsx
@@ -7,6 +7,7 @@ import { IoIosMail } from "react-icons/io";
 import { useRouter } from "next/navigation";
 import ModalBox from "@/components/atoms/ModalBox";
 import { HeaderBox } from "@/components/atoms/Box";
+import { usePathname } from "next/navigation";
 
 export default function LetterBoxLayout({
   children,
@@ -14,6 +15,10 @@ export default function LetterBoxLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
+  if (pathname === "/") {
+    return;
+  }
 
   const handleLetterWriteClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>

--- a/src/app/@modal/letter/letterdelete/layout.tsx
+++ b/src/app/@modal/letter/letterdelete/layout.tsx
@@ -3,12 +3,18 @@
 import MenuTab from "@/components/molecules/MenuTab";
 import ModalBox from "@/components/atoms/ModalBox";
 import { HeaderBox } from "@/components/atoms/Box";
+import { usePathname } from "next/navigation";
 
 export default function LetterBoxLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  if (pathname === "/") {
+    return;
+  }
+
   return (
     <ModalBox
       $width="430px"

--- a/src/app/@modal/letter/newletter/layout.tsx
+++ b/src/app/@modal/letter/newletter/layout.tsx
@@ -4,12 +4,18 @@ import MenuTab from "@/components/molecules/MenuTab";
 import ModalBox from "@/components/atoms/ModalBox";
 import { HeaderBox } from "@/components/atoms/Box";
 import { styled } from "styled-components";
+import { usePathname } from "next/navigation";
 
 export default function NewLetterLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  if (pathname === "/") {
+    return;
+  }
+
   return (
     <ModalBox
       $width="430px"

--- a/src/app/@modal/mypage/layout.tsx
+++ b/src/app/@modal/mypage/layout.tsx
@@ -4,8 +4,18 @@ import React from "react";
 import ModalBox from "@/components/atoms/ModalBox";
 import { HeaderBox } from "@/components/atoms/Box";
 import MenuTab from "@/components/molecules/MenuTab";
+import { usePathname } from "next/navigation";
 
-export default function layout({ children }: { children: React.ReactNode }) {
+export default function MyPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  if (pathname === "/") {
+    return;
+  }
+
   return (
     <ModalBox
       $width="320px"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,14 @@
-"use client";
-
+import type { Metadata } from "next";
 import StyledComponentsRegistry from "@/lib/api/reistry";
-import { RecoilRoot } from "recoil";
-import LoadingSpinner from "@/components/atoms/LoadingSpinner";
-import { usePathname } from "next/navigation";
 import { memo } from "react";
+import ClientProviders from "@/components/ClientProviders";
+
+export const metadata: Metadata = {
+  title: "TO. Letter",
+  description: `[온라인을 통해 만나는 아날로그한 편지, TO. Letter]
+  가상의 나의 방에서 편지를 주고 받을 수 있어요(내가 설정해둔 우편함 위치를 기준으로 편지가 도착하는 시간이 정해져요!).
+  나의 편지 주소를 SNS에 공유하여 주변 사람들과 편지를 주고 받아보세요.`,
+};
 
 const RootLayout = memo(
   ({
@@ -14,18 +18,15 @@ const RootLayout = memo(
     children: React.ReactNode;
     modal: React.ReactNode;
   }) => {
-    const pathname = usePathname();
-
     return (
       <html lang="ko">
         <body>
-          <RecoilRoot>
-            <StyledComponentsRegistry>
-              <LoadingSpinner />
+          <StyledComponentsRegistry>
+            <ClientProviders>
               {children}
-              {pathname === "/" ? <></> : modal}
-            </StyledComponentsRegistry>
-          </RecoilRoot>
+              {modal}
+            </ClientProviders>
+          </StyledComponentsRegistry>
         </body>
       </html>
     );

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { RecoilRoot } from "recoil";
+import LoadingSpinner from "@/components/atoms/LoadingSpinner";
+import { ReactNode } from "react";
+
+const ClientProviders = ({ children }: { children: ReactNode }) => {
+  return (
+    <RecoilRoot>
+      <LoadingSpinner />
+      {children}
+    </RecoilRoot>
+  );
+};
+
+export default ClientProviders;

--- a/src/components/molecules/MenuTab.tsx
+++ b/src/components/molecules/MenuTab.tsx
@@ -1,16 +1,9 @@
 "use client";
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-"use client";
-import React, { useEffect } from "react";
+import React, { useMemo } from "react";
 import Tab from "@/components/atoms/Tab";
 import { usePathname, useRouter } from "next/navigation";
 import { NavBox } from "../atoms/Box";
-import {
-  type menuTabDataI,
-  type menuI,
-  menuList,
-} from "@/lib/constants/menuTabList";
+import { type menuTabDataI, menuList } from "@/lib/constants/menuTabList";
 
 type MenuListKeys = keyof typeof menuList;
 
@@ -21,14 +14,17 @@ type MenuListKeys = keyof typeof menuList;
 export default function MenuTab() {
   const router = useRouter();
   const pathname = usePathname();
-  const [firstPath, secondPath] = pathname.split("/").filter(Boolean);
-  console.log("pathname", pathname);
 
-  const pathKey = (
-    firstPath in menuList ? firstPath : secondPath
-  ) as MenuListKeys;
+  // `pathKey` 계산 최적화
+  const pathKey = useMemo(() => {
+    const [firstPath, secondPath] = pathname.split("/").filter(Boolean);
+    return (firstPath in menuList ? firstPath : secondPath) as MenuListKeys;
+  }, [pathname]);
 
-  const { category, menuTabData, tabOption } = menuList[pathKey];
+  // `menuList[pathKey]` 추출 최적화
+  const { category, menuTabData, tabOption } = useMemo(() => {
+    return menuList[pathKey];
+  }, [pathKey]);
 
   if (tabOption === "underline") {
     return (


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number
#86 [perf] 컴포넌트 및 함수 재활용
#88 [perf] 검색 엔진 최적화(SEO)

<br/>

## 📝 요약(Summary)
### RootLayout ssr 처리 및 metadata 적용
1. RootLayout ssr 처리를 위한 ClientProviders(recoil 코드 분리) 생성
    + metadata의 경우 server component에서만 사용이 가능하고 recoil의 경우 client component에서만 사용이 가능하여 분리
    + 레퍼런스1-RecoilProvider 적용 / 레퍼런스2-Recoil doesn't work server side with Next.js 13 참고

 ### modal path가 아닌 경우에도 menuTab 이 호출되어 생기는 menuKey 관련 에러 처리
 + RootLayout ssr 처리에 따라 RootLayout에서 usePathname 사용이 불가능 하여 "use Client"를 사용하는 modal 하위 layout에서 분기처리

<br/>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>

## 📸스크린샷 (선택)
+ metadata 적용
![image](https://github.com/user-attachments/assets/c60048a2-7f3f-4b04-b593-ea153183f550)

<br/>

## 💬 공유사항
1. 모달 창 X표시 문제
[modal path가 아닌 경우에도 menuTab 이 호출되어 생기는 menuKey 관련 에러 처리] 부분 작업 결과로 인해 공유 및 편지 쓰기, 편지쓰기 닉네임 검사 등 menuTab을 사용하지 않는 경우의 modal 부분이 '/'로 path가 변경되었음에도 꺼지지 않는 현상이 발견
api 기능 부분 작업하면서 같이 대응하거나, modal 렌더링 방식 부분에 대해 다시 이슈를 열 필요 존재

2. 차후 ssr을 지원하는 전역 상태 관리 라이브러리 교체 가능성 염두 필요
레퍼런스3 참고

<br/>

## 📚 코드 이해에 필요한(혹은 본인이 이해하는데 사용한) 레퍼런스 목록
[레퍼런스1-RecoilProvider 적용](https://banal7.tistory.com/32)
[레퍼런스2-Recoil doesn't work server side with Next.js 13](https://github.com/facebookexperimental/Recoil/issues/2261)
[레퍼런스3-ssr recoil 사용 메모리 누수 문제](https://medium.com/@clockclcok/recoil-%EC%9D%B4%EC%A0%9C%EB%8A%94-%EB%96%A0%EB%82%98-%EB%B3%B4%EB%82%BC-%EC%8B%9C%EA%B0%84%EC%9D%B4%EB%8B%A4-ff2c8674cdd5)

