### PR TITLE
[fix] modal path name bug

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,10 +22,7 @@ const RootLayout = memo(
       <html lang="ko">
         <body>
           <StyledComponentsRegistry>
-            <ClientProviders>
-              {children}
-              {modal}
-            </ClientProviders>
+            <ClientProviders modal={modal}>{children}</ClientProviders>
           </StyledComponentsRegistry>
         </body>
       </html>

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -3,12 +3,22 @@
 import { RecoilRoot } from "recoil";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { ReactNode } from "react";
+import { usePathname } from "next/navigation";
 
-const ClientProviders = ({ children }: { children: ReactNode }) => {
+const ClientProviders = ({
+  children,
+  modal,
+}: {
+  children: ReactNode;
+  modal: ReactNode;
+}) => {
+  const pathname = usePathname();
+
   return (
     <RecoilRoot>
       <LoadingSpinner />
       {children}
+      {pathname === "/" ? null : modal}
     </RecoilRoot>
   );
 };

--- a/src/components/atoms/Box.tsx
+++ b/src/components/atoms/Box.tsx
@@ -13,6 +13,7 @@ interface defaultStyleProps {
   $border?: string;
   $backgroundColor?: string;
   $borderRadius?: string;
+  $color?: string;
 }
 
 /**
@@ -30,6 +31,7 @@ const flexMixin = css<defaultStyleProps>`
   border: ${({ $border }) => $border};
   background-color: ${({ $backgroundColor }) => $backgroundColor};
   border-radius: ${({ $borderRadius }) => $borderRadius};
+  color: ${({ $color }) => $color};
 `;
 
 /**
@@ -50,6 +52,7 @@ const BaseBox = styled.div<defaultStyleProps>`
  * @param $border?: string;
  * @param $backgroundColor?: string;
  * @param $borderRadius?: string;
+ * @param $color?: string;
  * @returns header제외 전체 콘텐츠에 대한 main Box(main tag)
  */
 export const MainBox = styled(BaseBox).attrs({ as: "main" })``;
@@ -65,6 +68,7 @@ export const MainBox = styled(BaseBox).attrs({ as: "main" })``;
  * @param $border?: string;
  * @param $backgroundColor?: string;
  * @param $borderRadius?: string;
+ * @param $color?: string;
  * @returns header 콘텐츠에 대한 header Box(header tag)
  */
 export const HeaderBox = styled(BaseBox).attrs({ as: "header" })``;
@@ -80,6 +84,7 @@ export const HeaderBox = styled(BaseBox).attrs({ as: "header" })``;
  * @param $border?: string;
  * @param $backgroundColor?: string;
  * @param $borderRadius?: string;
+ * @param $color?: string;
  * @returns header 안의 nav 콘텐츠에 대한 nav Box(nav tag)
  */
 export const NavBox = styled(BaseBox).attrs({ as: "nav" })``;
@@ -94,6 +99,7 @@ export const NavBox = styled(BaseBox).attrs({ as: "nav" })``;
  * @param $border?: string;
  * @param $backgroundColor?: string;
  * @param $borderRadius?: string;
+ * @param $color?: string;
  * @returns 각각의 내용 콘텐츠에 대한 Section용 Box(section tag)
  */
 export const SectionBox = styled(BaseBox).attrs({ as: "section" })``;
@@ -109,6 +115,7 @@ export const SectionBox = styled(BaseBox).attrs({ as: "section" })``;
  * @param $border?: string;
  * @param $backgroundColor?: string;
  * @param $borderRadius?: string;
+ * @param $color?: string;
  * @returns 구역 나눌 때 사용하는 Box(div tag)
  */
 export const ElementBox = styled(BaseBox)``;

--- a/src/components/canvas/models/Desk.tsx
+++ b/src/components/canvas/models/Desk.tsx
@@ -102,7 +102,7 @@ const Desk = () => {
     /*     if (axiosInterceptor.defaults.headers.common["Authorization"] !== null) {
       router.push("/letter/userconfirm");
     } */
-    router.push("/letter/letterbox/receive");
+    router.push("/letter/userconfirm");
   };
 
   return (

--- a/src/components/organisms/letter/LetterWriteContents.tsx
+++ b/src/components/organisms/letter/LetterWriteContents.tsx
@@ -46,11 +46,12 @@ const LetterWriteContents: React.FC = () => {
 
   /** 편지 내용이 있는 경우 편지 보내기 모달로 이동하는 함수 */
   const moveSendLetterModal = () => {
-    if (nicknameAndContents.contents !== "") {
+    /* if (nicknameAndContents.contents !== "") {
       router.push("/letter/lettersend");
     } else {
       setToast({ message: "편지에 내용을 써주세요.", visible: true });
-    }
+    } */
+    router.push("/letter/lettersend");
   };
 
   /** 편지 내용 스크롤 이벤트 관리 */
@@ -85,7 +86,7 @@ const LetterWriteContents: React.FC = () => {
     };
   }, [handleClickOutside]);
   return (
-    <LetterWrap ref={modalRef} $padding="10px" $width="700px">
+    <LetterWrap ref={modalRef} $padding="10px" $width="700px" $color="black">
       <CloseButton onClick={() => router.push("/")}>
         <IoMdClose />
       </CloseButton>

--- a/src/components/organisms/letter/NicknameConfirmContents.tsx
+++ b/src/components/organisms/letter/NicknameConfirmContents.tsx
@@ -64,11 +64,12 @@ const NicknameConfirmContents: React.FC = () => {
    * 편지 쓰기 모달로 이동 함수
    */
   const moveLetter = () => {
-    if (isNicknameChecked) {
+    router.push("/letter/letterwrite");
+    /* if (isNicknameChecked) {
       router.push("/letter/letterwrite");
     } else {
       setToast({ message: "닉네임 확인을 완료해주세요.", visible: true });
-    }
+    } */
   };
 
   return (


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#104 [Bug] root layout ssr전환으로 인한 modal path bug

<br/>
<br/>

## 📝 요약(Summary)

1. #103 의 변경사항으로 인해서 공유 및 편지 쓰기, 편지쓰기 닉네임 검사 등 menuTab을 사용하지 않는 경우의 modal 부분이 '/'로 path가 변경되었음에도 꺼지지 않는 현상
2. root layout을 ssr components 변환 과정에서 기존의 pathname에 따른 modal의 비교 로직을 삭제 했기 때문
4. Root Layout이 아닌 csr components의 하위 layout인 ClientProviders에 porps로 modal을 전달
5. ClientProviders에서 기존의 pathname에 따른 modal의 비교 로직 추가(pathname === "/" ? null : modal)

<br/>
<br/>


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>

## 📸스크린샷 (선택)

![모달-pathname-해결](https://github.com/user-attachments/assets/c319d81a-8c3d-48cb-aa91-6ba11fdf6cd6)

<br/>
<br/>


## 💬 공유사항

<!--- 차후 작업 시 염두해야할 부분 -->

1. modal들의 점검을 위해서 편지 쓰기 부분을 점검하던 중 편지 쓰기 모달의 To.와 From. text color가 white임을 확인
atom폴더의 Box defaultStyleProps에 color 속성 추가
2. organisms/letter/LetterWriteContents의 LetterWrap에 color추가

<br/>
<br/>


## 📚 코드 이해에 필요한(혹은 본인이 이해하는데 사용한) 레퍼런스 목록

[#103 [feat] seo meta tag root layout pull request](https://github.com/To-Letter/To-Letter-front/pull/103)

<br/>
<br/>

