### PR TITLE
fix: url 직접 접근시 가이드 페이지로 redirect #87

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,10 +22,6 @@ const nextConfig = {
         source: "/:path*",
         headers: [
           {
-            key: "Permissions-Policy",
-            value: "browsing-topics=(), interest-cohort=(), cookies=()",
-          },
-          {
             key: "Cache-Control",
             value: "public, max-age=3600, must-revalidate",
           },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,8 +33,14 @@ export default function Home() {
     };
   }, []);
 
-  /** kakao 리다이렉션 페이지에서 모달 전환을 위한 파라미터 처리 */
+  /** 보호된 경로와 kakao 리다이렉션 페이지에서 모달 전환을 위한 파라미터 처리 */
   useEffect(() => {
+    const showLogin = searchParams.get("showLogin");
+
+    if (showLogin === "true") {
+      // 패러렐 라우트를 사용하여 로그인 모달 표시
+      router.push("/auth/login");
+    }
     if (searchParams.get("modal") === "kakao-signup") {
       router.push("/auth/kakao");
     } else if (searchParams.get("modal") === "login") {
@@ -43,14 +49,14 @@ export default function Home() {
   }, [searchParams, router]);
 
   useEffect(() => {
-    // 모델이 로드되지 않은 상태라면 가이드 페이지로 리다이렉트
+    /** 모델이 로드되지 않은 상태라면 가이드 페이지로 리다이렉트 */
     if (progress < 100) {
       router.push("/guide");
       return;
     }
   }, [progress, router]);
 
-  // 모델이 로드되지 않았다면 빈 화면을 보여줌
+  /** 모델이 로드되지 않았다면 빈 화면을 보여줌 */
   if (progress < 100) return null;
 
   const isAuthorized =

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// 로그인이 필요한 경로들
+const PROTECTED_PATHS = [
+  "/auth/address",
+  "/auth/kakao",
+  "/auth/verify",
+  "/letter",
+  "/mypage",
+  "/share",
+  "/users",
+];
+
+// 공개 경로들 (로그인 없이 접근 가능)
+const PUBLIC_PATHS = ["/", "/guide", "/photo", "/auth/login", "/auth/signup"];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Authorization 헤더 또는 쿠키에서 토큰 확인
+  const token = request.headers.get("Authorization")?.replace("Bearer ", "");
+
+  // 보호된 경로에 접근하려고 할 때
+  if (PROTECTED_PATHS.some((path) => pathname.startsWith(path))) {
+    // 토큰이 없으면
+    if (!token) {
+      // URL에 현재 시도한 경로를 state로 포함
+      const url = new URL("/", request.url);
+      url.searchParams.set("showLogin", "true");
+
+      return NextResponse.redirect(url);
+    }
+  }
+
+  // 허용되지 않은 경로로 접근할 때 (에러페이지 대신 홈으로)
+  if (
+    !PUBLIC_PATHS.some((path) => pathname.startsWith(path)) &&
+    !PROTECTED_PATHS.some((path) => pathname.startsWith(path))
+  ) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*",
+};


### PR DESCRIPTION
## #️⃣ Issue Number

#87 [migration] nextjs 변환

<br/>
<br/>

## 📝 요약(Summary)

1. url로 직접 라우터 경로 접근시 에러페이지와 경로에 맞는 모달이 표시되는 버그 발견
2. 미들웨어로 제어해서 로그인이 필요한 서비스에 url 직접 접근시 가이드 페이지로 리다이렉트

<br/>
<br/>


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>


## 💬 공유사항

이제 서버와의 api통신할 때 try catch에서 catch에 잡히는 에러 핸들링에 대한 작업을 할건데 이 이슈에 대한 생각이 궁금함


<br/>
<br/>


## 📚 코드 이해에 필요한(혹은 본인이 이해하는데 사용한) 레퍼런스 목록

[refo](https://algoroot.tistory.com/119)


<br/>
<br/>

