### PR TITLE
hotfix: 카카오 로그인, 회원가입 리다이렉션 버그 처리 #87

### DIFF
--- a/src/app/users/kakao/page.tsx
+++ b/src/app/users/kakao/page.tsx
@@ -7,10 +7,13 @@ import { loadingState } from "@/store/recoil/loadingAtom";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { postKakaoToken } from "@/lib/api/controller/account";
 import { signupState } from "@/store/recoil/accountAtom";
+import { useModelLoadingStore } from "@/store/recoil/zustand/modelLoadingStore";
 
 export default function KakaoCallback() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  /* 임의로 모델 로딩 상태 관리 zustand */
+  const { disableLoading } = useModelLoadingStore();
   /** 로딩 상태 관리 recoil */
   const setLoadingState = useSetRecoilState(loadingState);
   /** 회원가입 정보 관리 recoil */
@@ -38,7 +41,9 @@ export default function KakaoCallback() {
           ...prev,
           email: res.data.responseData.email,
         }));
+        router.replace("/?modal=kakao-signup");
       } else if (res.data.responseCode === 201) {
+        disableLoading();
         router.replace("/");
       } else if (res.data.responseCode === 400) {
         setSignupForm((prev) => ({
@@ -51,16 +56,20 @@ export default function KakaoCallback() {
         router.replace("/?modal=login");
       } else if (res.data.responseCode === 403) {
         alert("동일한 이메일이 존재합니다.");
+        disableLoading();
         router.replace("/");
       } else if (res.data.responseCode === 404) {
         alert("존재하지 않는 이메일입니다.");
+        disableLoading();
         router.replace("/");
       } else {
         alert("카카오 로그인 오류입니다. 다시 로그인해주세요.");
         router.replace("/?modal=login");
+        console.log("kakao : ", 405);
       }
     } catch (error: any) {
       alert("카카오 로그인 중 오류가 발생했습니다.");
+      disableLoading();
       router.push("/");
     } finally {
       setLoadingState(false);

--- a/src/lib/api/controller/account.ts
+++ b/src/lib/api/controller/account.ts
@@ -179,16 +179,11 @@ export const postKakaoToken = async (code: { code: string }) => {
     if (response.data.responseCode === 201) {
       /* 이미 회원가입이 되있는 유저에 대한 토큰 저장 -> 로그인 */
       const accessToken = response.headers.get("authorization");
-      const refreshToken = response.headers.get("refreshToken");
 
       if (accessToken) {
         axiosInterceptor.defaults.headers.common[
           "Authorization"
         ] = `${accessToken}`;
-      }
-
-      if (refreshToken) {
-        axiosInterceptor.defaults.headers.common["refreshToken"] = refreshToken;
       }
     }
 

--- a/src/store/recoil/zustand/modelLoadingStore.ts
+++ b/src/store/recoil/zustand/modelLoadingStore.ts
@@ -8,6 +8,7 @@ interface ModalLoadingState {
   setTotalModels: (callback: (prev: number) => number) => void;
   incrementLoadedCount: () => void;
   resetLoading: () => void;
+  disableLoading: () => void;
 }
 
 export const useModelLoadingStore = create<ModalLoadingState>((set) => ({
@@ -44,5 +45,13 @@ export const useModelLoadingStore = create<ModalLoadingState>((set) => ({
       loadedCount: 0,
       progress: 0,
       isComplete: false,
+    }),
+
+  disableLoading: () =>
+    set({
+      totalModels: 13,
+      loadedCount: 13,
+      progress: 100,
+      isComplete: true,
     }),
 }));


### PR DESCRIPTION
## #️⃣ Issue Number

#87 [migration] nextjs 변환

<br/>
<br/>

## 📝 요약(Summary)

1. 카카오 회원가입 200코드에 대한 리다이렉션 처리가 안 되있어 처리함
2. 카카오 로그인 리다이렉션 처리중 루트페이지로(로그인된 시점)으로 가야 하는데 zustand로 관리하는 progress때문에 계속 가이드 페이지로 넘어가는 버그 발견 -> 임의로 progress를 조정하는 disableLoading을 구현해 적용

<br/>
<br/>


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>


## 💬 공유사항

해결이 될지 안 될지 지켜보고 안 되면 다시 방법을 갈구해야함..


<br/>
<br/>

