### PR TITLE
fix: 마이페이지 내 정보 수정 없이 다른 탭, 혹은 나가기 버튼을 클릭 했을 때 입력한 데이터 값이 남아있는 현상 제거

### DIFF
--- a/src/components/organisms/mypage/MyInfoContents.tsx
+++ b/src/components/organisms/mypage/MyInfoContents.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ChangeEvent, useRef, useState } from "react";
+import React, { ChangeEvent, useEffect, useRef, useState } from "react";
 import { styled } from "styled-components";
 import { useRouter } from "next/navigation";
 import { ElementBox, MainBox, SectionBox } from "@/components/atoms/Box";
@@ -31,6 +31,9 @@ export default function MyInfoContents() {
   const [isNicknameChecked, setIsNicknameChecked] = useState(false);
   /** 초기 닉네임 저장 */
   const [originalNickname] = useState(myInfo.nickname);
+  /** 주소 변경 페이지 이동 감지 */
+  const [isFromAddressPage, setIsFromAddressPage] = useState(false);
+  const [prevPathname, setPrevPathname] = useState<string>("");
   /** 토스트 메시지 */
   const [toast, setToast] = useState<{ message: string; visible: boolean }>({
     message: "",
@@ -48,6 +51,7 @@ export default function MyInfoContents() {
 
   /** 주소 입력 모달 열기 함수 */
   const onClickOpenModal = () => {
+    setIsFromAddressPage(true);
     router.push("/auth/address");
   };
 
@@ -126,6 +130,21 @@ export default function MyInfoContents() {
       });
     }
   };
+
+  useEffect(() => {
+    return () => {
+      const nextPath = window.location.pathname;
+
+      // 주소 변경 페이지로 이동하는 경우가 아닐 때만 refreshMyInfo 실행
+      if (
+        !nextPath.includes("/auth/address") &&
+        !nextPath.includes("/mypage/myinfo")
+      ) {
+        refreshMyInfo();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <MainBox $direction="column" $alignItems="flex-start" $width="100%">


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->


## 📝 요약(Summary)
+ 마이페이지 내 정보 수정 없이 다른 탭, 혹은 나가기 버튼을 클릭 했을 때 입력한 데이터 값이 남아있는 현상 제거
     + 기존 구조를 변경하는 것은 품이 많이 든다고 판단하여, 데이터 변경 없이 다른 탭, 혹은 나가기 버튼을 클릭했을 경우 MyInfoContents useEffect에서 cleanup 함수를 사용하여 서버와 내 정보 동기화 처리. 주소 입력 모달 창으로 경로 변경된 경우 입력한 값이 유지되도록 예외처리 

<br/>


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

