### PR TITLE
fix: SummaryTip 깨짐 및 개별 편지 닉네임 버그 해결 #87

### DIFF
--- a/src/app/users/kakao/page.tsx
+++ b/src/app/users/kakao/page.tsx
@@ -65,7 +65,6 @@ export default function KakaoCallback() {
       } else {
         alert("카카오 로그인 오류입니다. 다시 로그인해주세요.");
         router.replace("/?modal=login");
-        console.log("kakao : ", 405);
       }
     } catch (error: any) {
       alert("카카오 로그인 중 오류가 발생했습니다.");

--- a/src/components/molecules/SummaryTip.tsx
+++ b/src/components/molecules/SummaryTip.tsx
@@ -60,7 +60,7 @@ export const SummryWrap = styled.div<defaultStyleProps>`
 
 export const TipBox = styled.div<defaultStyleProps>`
   display: none;
-  position: absolute;
+  position: fixed;
   bottom: ${({ $bottom }) => $bottom};
   left: ${({ $left }) => $left};
   transform: translateX(-50%);
@@ -69,7 +69,7 @@ export const TipBox = styled.div<defaultStyleProps>`
   padding: 5px;
   border-radius: 3px;
   white-space: break-spaces;
-  z-index: 10;
+  z-index: 9999;
   width: 200px;
   text-align: center;
   word-break: keep-all;

--- a/src/components/organisms/letter/LetterSendContents.tsx
+++ b/src/components/organisms/letter/LetterSendContents.tsx
@@ -82,6 +82,8 @@ const LetterSendContents: React.FC = () => {
               편지를 이대로 보내시겠습니까
               <SummaryTip
                 $margin="0 0 0 4px"
+                $bottom="411px"
+                $left="59%"
                 tipText="※ To. Letter의 편지는 유저들이 등록한 주소 거리에 기반하여 우편 도착시간이 결정됩니다."
               />
             </ElementBox>

--- a/src/components/organisms/letter/NewLetterContents.tsx
+++ b/src/components/organisms/letter/NewLetterContents.tsx
@@ -33,6 +33,7 @@ export default function NewLettersubject() {
       const formattedMails = listLetter.map((letter: any) => ({
         id: letter.id,
         sender: letter.fromUserNickname,
+        receiver: letter.toUserNickname,
         subject: letter.contents,
         timeReceived: letter.arrivedAt,
         viewCheck: letter.viewCheck,
@@ -55,7 +56,7 @@ export default function NewLettersubject() {
   const handleMailItemClick = (mail: Mail) => {
     setIndividualLetterInfo({
       id: mail.id,
-      toUserNickname: mail.sender,
+      toUserNickname: mail.receiver,
       letterContent: mail.subject,
       fromUserNickname: mail.sender,
       onDelete: true,

--- a/src/components/organisms/letter/NicknameConfirmContents.tsx
+++ b/src/components/organisms/letter/NicknameConfirmContents.tsx
@@ -93,8 +93,8 @@ const NicknameConfirmContents: React.FC = () => {
             <ElementBox $alignItems="center" $justifyContent="center">
               받는 사람 닉네임
               <SummaryTip
-                $margin="0 8px"
-                $bottom="24px"
+                $bottom="421px"
+                $left="52%"
                 tipText="편지를 보내는 사람의 닉네임이 존재하는지 확인해주세요."
               />
             </ElementBox>

--- a/src/components/organisms/letter/ReceiveLetters.tsx
+++ b/src/components/organisms/letter/ReceiveLetters.tsx
@@ -40,6 +40,7 @@ export function ReceiveLetters() {
       const formattedMails = listLetter.map((letter: any) => ({
         id: letter.id,
         sender: letter.fromUserNickname,
+        receiver: letter.toUserNickname,
         subject: letter.contents,
         timeReceived: letter.arrivedAt,
         viewCheck: letter.viewCheck,
@@ -62,7 +63,7 @@ export function ReceiveLetters() {
   const handleLetterClick = async (mail: Mail) => {
     setIndividualLetterInfo({
       id: mail.id,
-      toUserNickname: mail.sender,
+      toUserNickname: mail.receiver,
       letterContent: mail.subject,
       fromUserNickname: mail.sender,
       onDelete: false,

--- a/src/components/organisms/letter/ReceiveLettersDeleteContents.tsx
+++ b/src/components/organisms/letter/ReceiveLettersDeleteContents.tsx
@@ -18,6 +18,7 @@ import useDebounce from "@/hooks/useDebounce";
 interface Mail {
   id: number;
   sender: string;
+  receiver: string;
   subject: string;
   timeReceived: string;
 }
@@ -113,6 +114,7 @@ const ReceiveLettersDeleteContents = () => {
       const formattedMails = listLetter.map((letter: any) => ({
         id: letter.id,
         sender: letter.fromUserNickname,
+        receiver: letter.toUserNickname,
         subject: letter.contents,
         timeReceived: letter.arrivedAt,
         viewCheck: letter.viewCheck,
@@ -143,7 +145,7 @@ const ReceiveLettersDeleteContents = () => {
   const handleLetterClick = async (mail: Mail) => {
     setIndividualLetterInfo({
       id: mail.id,
-      toUserNickname: mail.sender,
+      toUserNickname: mail.receiver,
       letterContent: mail.subject,
       fromUserNickname: mail.sender,
       onDelete: true,
@@ -164,8 +166,6 @@ const ReceiveLettersDeleteContents = () => {
 
   /** 초기 받은 편지 데이터 로드 */
   useEffect(() => {
-    console.log("confirmMailDelete", confirmMailDelete);
-
     getAllReceiveLetters(0);
   }, [getAllReceiveLetters, confirmMailDelete]);
 

--- a/src/components/organisms/letter/SendLetters.tsx
+++ b/src/components/organisms/letter/SendLetters.tsx
@@ -37,6 +37,7 @@ export function SendLetters() {
       const formattedMails = listLetter.map((letter: any) => ({
         id: letter.id,
         sender: letter.fromUserNickname,
+        receiver: letter.toUserNickname,
         subject: letter.contents,
         timeReceived: letter.createdAt,
       }));
@@ -57,7 +58,7 @@ export function SendLetters() {
   const handleLetterClick = async (mail: Mail) => {
     setIndividualLetterInfo({
       id: mail.id,
-      toUserNickname: mail.sender,
+      toUserNickname: mail.receiver,
       letterContent: mail.subject,
       fromUserNickname: mail.sender,
       onDelete: false,

--- a/src/components/organisms/letter/SendLettersDeleteContents.tsx
+++ b/src/components/organisms/letter/SendLettersDeleteContents.tsx
@@ -104,6 +104,7 @@ const SendLettersDeleteContents = () => {
       const formattedMails = listLetter.map((letter: any) => ({
         id: letter.id,
         sender: letter.fromUserNickname,
+        receiver: letter.toUserNickname,
         subject: letter.contents,
         timeReceived: letter.createdAt,
       }));
@@ -132,7 +133,7 @@ const SendLettersDeleteContents = () => {
   const handleLetterClick = async (mail: Mail) => {
     setIndividualLetterInfo({
       id: mail.id,
-      toUserNickname: mail.sender,
+      toUserNickname: mail.receiver,
       letterContent: mail.subject,
       fromUserNickname: mail.sender,
       onDelete: true,
@@ -153,7 +154,6 @@ const SendLettersDeleteContents = () => {
 
   /** 초기 받은 편지 데이터 로드 */
   useEffect(() => {
-    console.log("confirmMailDelete", confirmMailDelete);
     getAllSendLetters(0);
   }, [getAllSendLetters, confirmMailDelete]);
 

--- a/src/types/letterType.ts
+++ b/src/types/letterType.ts
@@ -4,6 +4,7 @@
 export interface Mail {
   id: number;
   sender: string;
+  receiver: string;
   subject: string;
   timeReceived: string;
   viewCheck?: boolean; // optional로 변경


### PR DESCRIPTION
## #️⃣ Issue Number

#86 [perf] 컴포넌트 및 함수 재활용
#87 [migration] nextjs 변환

<br/>
<br/>

## 📝 요약(Summary)

1. Summary Tip 모달 외부로 벗어날 때 잘리는 현상 -> position: fixed로 바꾸고 위치 조정으로 해결
2. 개별 편지 모달에서 To. From. 닉네임이 둘 다 같은 닉네임으로 표기되는 문제 발견 -> 서버에서 오는 편지 데이터에서 To. From. 닉네임 데이터를 하나만 적용시켜서 생긴 문제이므로 둘 다 적용하여 해결

<br/>
<br/>


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>


## 💬 공유사항

버그가 계속 나와~


<br/>
<br/>

